### PR TITLE
Snyk: Ignore vendor repo

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,7 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+ignore: {}
+patch: {}
+exclude:
+  global:
+    - '**/vendor/*'


### PR DESCRIPTION
Related to https://openly-engineering.atlassian.net/browse/SEC-66

In an ideal world, we would incorporate `snyk test`, `snyk code test`, and `snyk monitor` into the CircleCI pipeline here, but that's a lot of infrastructure for an aggregator that we very rarely contribute to.

We'll kick that can down the road for now, relying on Snyk's webhooks (as GH Actions) and concern ourselves with the false positives that Snyk presents by scanning both the go.mod and vendor/* files: there's overlap, and the paradigm we're following is to only be concerned with go.mod. This PR causes Snyk to ignore the vendor subdirectory.

Before:
```
Testing /Users/miranda/work/openly-engineering/openlynt ...

 ✗ [Low] Use of Password Hash With Insufficient Computational Effort
   Path: vendor/github.com/google/uuid/hash.go, line 44
   Info: The MD5 hash (used in crypto.md5.New) is insecure. Consider changing it to a secure hash algorithm

 ✗ [Low] Use of Password Hash With Insufficient Computational Effort
   Path: vendor/github.com/google/uuid/hash.go, line 52
   Info: The SHA1 hash (used in crypto.sha1.New) is insecure. Consider changing it to a secure hash algorithm

 ✗ [Low] Use of Password Hash With Insufficient Computational Effort
   Path: vendor/github.com/Masterminds/sprig/crypto.go, line 40
   Info: The SHA1 hash (used in crypto.sha1.Sum) is insecure. Consider changing it to a secure hash algorithm

 ✗ [Medium] Use of Hardcoded Credentials
   Path: vendor/github.com/Masterminds/sprig/crypto.go, line 54
   Info: Do not hardcode passwords in code. Found hardcoded saved in master_password_seed.


✔ Test completed
Summary:

  4 Code issues found
  1 [Medium]   3 [Low]
```

After:
```
Testing /Users/miranda/work/openly-engineering/openlynt ...

✔ Test completed

Organization:      e77bbafb-668b-440a-a980-7e6970627253
Test type:         Static code analysis
Project path:      /Users/miranda/work/openly-engineering/openlynt

Summary:

✔ Awesome! No issues were found.
```