### PR TITLE
Remove .snyk ignore file

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,7 +1,0 @@
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.25.0
-ignore: {}
-patch: {}
-exclude:
-  global:
-    - '**/vendor/*'


### PR DESCRIPTION
See #10 for introduction of this file

Resolves [openly-engineering.atlassian.net/browse/SEC-316](https://openly-engineering.atlassian.net/browse/SEC-316)

We're migrating from Snyk to Wiz. This PR removes the cruft of the config file that the Snyk CLI reads as I've added the rule to the Wiz console (see screenshot, below). For more information about the Snyk Code CLI ignore file, see this documentation: [docs.snyk.io/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/exclude-directories-and-files-from-snyk-code-cli-tests](https://docs.snyk.io/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/exclude-directories-and-files-from-snyk-code-cli-tests)

I checked the Wiz ignore using [digitalocean.com/community/tools/glob](https://www.digitalocean.com/community/tools/glob)

![Screenshot 2025-04-15 at 4 31 36 PM](https://github.com/user-attachments/assets/58975d63-9bfb-4618-b4f6-1e4f10846d63)
